### PR TITLE
Fixed time format issues, added heat/cool deadband

### DIFF
--- a/sdm-api-app.groovy
+++ b/sdm-api-app.groovy
@@ -506,6 +506,11 @@ def postEvents() {
     def deviceId = dataJson.resourceUpdate.name.tokenize('/')[-1]
     def device = getChildDevice(deviceId)
     if (device != null) {
+        // format back to millisecond decimal places in case the timestamp has nano-second resolution
+        int periodIndex = dataJson.timestamp.lastIndexOf('.')
+        dataJson.timestamp = dataJson.timestamp.substring(0, (periodIndex + 4))
+        dataJson.timestamp = dataJson.timestamp+"Z" 
+        
         def lastEvent = device.currentValue('lastEventTime')
         if (lastEvent == null) {
             lastEvent = '1970-01-01T00:00:00.000Z'

--- a/sdm-api-thermostat.groovy
+++ b/sdm-api-thermostat.groovy
@@ -95,30 +95,43 @@ def off() {
 }
 
 def setCoolingSetpoint(temp) {
+    def tempMovement = device.currentValue('heatingSetpoint').toFloat() - temp.toFloat() + 1.5
+    if (tempMovement <= 0) {
+        tempMovement = device.currentValue('heatingSetpoint')
+    } else {
+        tempMovement = device.currentValue('heatingSetpoint').toFloat() - tempMovement.toFloat()
+    }
     def mode = device.currentValue('thermostatMode')
     if (mode == 'cool') {
         parent.deviceSetTemperatureSetpoint(device, null, temp)
     } else if (mode == 'auto') {
-        parent.deviceSetTemperatureSetpoint(device, device.currentValue('heatingSetpoint'), temp)
+        parent.deviceSetTemperatureSetpoint(device, tempMovement, temp)
     } else {
         log.warn("Cannot setCoolingSetpoint in thermostatMode: ${mode}")
     }
 }
 
 def setHeatingSetpoint(temp) {
+    def tempMovement = temp.toFloat() - device.currentValue('coolingSetpoint').toFloat() + 1.5
+    if (tempMovement <= 0) {
+        tempMovement = device.currentValue('coolingSetpoint')
+    } else {
+        tempMovement = device.currentValue('coolingSetpoint').toFloat() + tempMovement.toFloat()
+    }
     def mode = device.currentValue('thermostatMode')
     if (mode == 'heat') {
         parent.deviceSetTemperatureSetpoint(device, temp, null)
     } else if (mode == 'auto') {
-        parent.deviceSetTemperatureSetpoint(device, temp, device.currentValue('coolingSetpoint'))
+        parent.deviceSetTemperatureSetpoint(device, temp, tempMovement)
     } else {
         log.warn("Cannot setHeatingSetpoint in thermostatMode: ${mode}")
     }
 }
 
 def setHeatCoolSetpoint(heat, cool) {
+    def tempMovement = heat.toFloat() - cool.toFloat() + 1.5
     def mode = device.currentValue('thermostatMode')
-    if (mode == 'auto') {
+    if ((mode == 'auto') && (tempMovement <= 0)) {
         parent.deviceSetTemperatureSetpoint(device, heat, cool)
     } else {
         log.warn("Cannot setHeatCoolSetpoint in thermostatMode: ${mode}")


### PR DESCRIPTION
It seems that 1 out of 5 of my Google devices reports JSON timestamps in nano-second precision.  The changes to the app force that to be formatted back to millisecond to eliminate the toDatetime() exceptions.  Works for both nano and milli timestamps.

If you are in heat/cool mode, Nest needs there to be a minimum 1.5C dead band between those two setpoints.  If you manually adjust the temperatures, it will automatically bump up/down the other setpoint to keep this rule valid.  The changes in the thermostat driver do the same for heat and cool mode.  In heat/cool, it just traps the error since there is no way to determine which setpoint "wins".
