### PR TITLE
Fixed the dead band adjustment 

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,13 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## 2024-11-12
+
+### sdm-api-app:1.1.3
+### sdm-api-thermostat:1.0.2
+* Round heat/cool set points and dead band calculation to one decimal place
+* Addresses issue with invalid set points when within the dead band range
+
 ## 2024-05-07
 
 ### sdm-api-app:1.1.2

--- a/packageManifest.json
+++ b/packageManifest.json
@@ -14,7 +14,7 @@
       "required": true,
       "oauth": true,
       "primary": true,
-      "version": "1.1.2"
+      "version": "1.1.3"
     }
   ],
   "drivers": [
@@ -24,7 +24,7 @@
       "namespace": "dkilgore90",
       "location": "https://raw.githubusercontent.com/dkilgore90/google-sdm-api/master/sdm-api-thermostat.groovy",
       "required": false,
-      "version": "1.0.1"
+      "version": "1.0.2"
     },
     {
       "id": "207a67b0-8790-41b9-8b5f-00467d55a00a",

--- a/sdm-api-app.groovy
+++ b/sdm-api-app.groovy
@@ -17,7 +17,7 @@ import groovy.json.JsonOutput
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  *
- *  version: 1.1.2
+ *  version: 1.1.3
  */
 
 definition(
@@ -540,7 +540,7 @@ def convertAndRoundTemp(value) {
     if (getTemperatureScale() == 'F') {
         return new Double(celsiusToFahrenheit(value)).round()
     } else {
-        return new Double(value * 2).round() / 2
+        return new Double(value).round(1)
     }
 }
 
@@ -823,16 +823,12 @@ def deviceSetTemperatureSetpoint(com.hubitat.app.DeviceWrapper device, heatPoint
         log.warn('Cannot adjust temperature setpoint(s) when device is in MANUAL_ECO mode')
         return
     }
-    if (device.currentValue('tempScale') == 'FAHRENHEIT') {
-        coolPoint = coolPoint ? fahrenheitToCelsius(coolPoint) : null
-        heatPoint = heatPoint ? fahrenheitToCelsius(heatPoint) : null
-    }
     if (coolPoint && heatPoint) {
-        deviceSendCommand(device, 'sdm.devices.commands.ThermostatTemperatureSetpoint.SetRange', [coolCelsius: coolPoint, heatCelsius: heatPoint])
+        deviceSendCommand(device, 'sdm.devices.commands.ThermostatTemperatureSetpoint.SetRange', [coolCelsius: convertAndRoundTemp(coolPoint), heatCelsius: convertAndRoundTemp(heatPoint)])
     } else if (coolPoint) {
-        deviceSendCommand(device, 'sdm.devices.commands.ThermostatTemperatureSetpoint.SetCool', [coolCelsius: coolPoint])
+        deviceSendCommand(device, 'sdm.devices.commands.ThermostatTemperatureSetpoint.SetCool', [coolCelsius: convertAndRoundTemp(coolPoint)])
     } else if (heatPoint) {
-        deviceSendCommand(device, 'sdm.devices.commands.ThermostatTemperatureSetpoint.SetHeat', [heatCelsius: heatPoint])
+        deviceSendCommand(device, 'sdm.devices.commands.ThermostatTemperatureSetpoint.SetHeat', [heatCelsius: convertAndRoundTemp(heatPoint)])
     }
 }
 

--- a/sdm-api-thermostat.groovy
+++ b/sdm-api-thermostat.groovy
@@ -41,7 +41,9 @@ metadata {
         command 'fanOn', [[name: 'duration', type: 'NUMBER', description: 'length of time, in seconds']]
         command 'setThermostatFanMode', [[name: 'fanmode', type: 'ENUM', constraints: ['auto', 'on']], [name: 'duration', type: 'NUMBER', description: 'length of time, in seconds']]
         command 'setEcoMode', [[name: 'ecoMode*', type: 'ENUM', constraints: ['OFF', 'MANUAL_ECO']]]
-        command 'setHeatCoolSetpoint', [[name: 'heatPoint*', type: 'NUMBER'], [name: 'coolPoint*', type: 'NUMBER']]
+        command 'setHeatCoolSetpoint', [[name: 'heatPoint*', type: 'DECIMAL'], [name: 'coolPoint*', type: 'DECIMAL']]       
+        command 'setHeatingSetpoint', [[name: 'heatPoint*', type: 'DECIMAL']]
+        command 'setCoolingSetpoint', [[name: 'coolPoint*', type: 'DECIMAL']]
     }
     
     preferences {

--- a/sdm-api-thermostat.groovy
+++ b/sdm-api-thermostat.groovy
@@ -16,7 +16,7 @@ import groovy.json.JsonOutput
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  *
- *  version: 1.0.1
+ *  version: 1.0.2
  */
 
 metadata {
@@ -119,7 +119,7 @@ def setCoolingSetpoint(temp) {
         def heat = device.currentValue('heatingSetpoint')
         def tempMovement = checkDeadband(heat, temp)
         if (tempMovement > 0) {
-            heat = heat.toFloat() - tempMovement.toFloat()
+            heat = heat.toDouble() - tempMovement.toDouble()
         }
         parent.deviceSetTemperatureSetpoint(device, heat, temp)
     } else {
@@ -135,7 +135,7 @@ def setHeatingSetpoint(temp) {
         def cool = device.currentValue('coolingSetpoint')
         def tempMovement = checkDeadband(temp, cool)
         if (tempMovement > 0) {
-            cool = cool.toFloat() + tempMovement.toFloat()
+            cool = cool.toDouble() + tempMovement.toDouble()
         }
         parent.deviceSetTemperatureSetpoint(device, temp, cool)
     } else {
@@ -160,8 +160,8 @@ def setHeatCoolSetpoint(heat, cool) {
 def checkDeadband(heat, cool) {
     try {
         def deadband = getTemperatureScale() == 'F' ? 2.7 : 1.5
-        def tempMovement = heat.toFloat() - cool.toFloat() + deadband
-        return tempMovement
+        def tempMovement = heat.toDouble() - cool.toDouble() + deadband.toDouble()
+        return (tempMovement.round(1))
     } catch (NullPointerException e) {
         return 0
     }

--- a/sdm-api-thermostat.groovy
+++ b/sdm-api-thermostat.groovy
@@ -41,9 +41,7 @@ metadata {
         command 'fanOn', [[name: 'duration', type: 'NUMBER', description: 'length of time, in seconds']]
         command 'setThermostatFanMode', [[name: 'fanmode', type: 'ENUM', constraints: ['auto', 'on']], [name: 'duration', type: 'NUMBER', description: 'length of time, in seconds']]
         command 'setEcoMode', [[name: 'ecoMode*', type: 'ENUM', constraints: ['OFF', 'MANUAL_ECO']]]
-        command 'setHeatCoolSetpoint', [[name: 'heatPoint*', type: 'DECIMAL'], [name: 'coolPoint*', type: 'DECIMAL']]       
-        command 'setHeatingSetpoint', [[name: 'heatPoint*', type: 'DECIMAL']]
-        command 'setCoolingSetpoint', [[name: 'coolPoint*', type: 'DECIMAL']]
+        command 'setHeatCoolSetpoint', [[name: 'heatPoint*', type: 'NUMBER'], [name: 'coolPoint*', type: 'NUMBER']]
     }
     
     preferences {


### PR DESCRIPTION
Previously, I had made the dead band adjustment to increase the cool or decrease the hot set points the amount to ensure there was 1.5C/2.7F of dead band per the API documentation.

I was seeing issues which were spawning from rounding on the heat/cool points when at that dead band threshold.  I would try to bump up the cool set point by the delta, and get a "invalid cool set point" response from the Google API.

I've changed the code to now increase the cool set point by the dead band + heat point or decrease the heat set point by cool point - dead band to ensure there is at least the dead band of temperature difference.

The app will now properly round to 1-decimal place when setting the request back to Google to prevent larger fractional temperatures.